### PR TITLE
chore: upgrade minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jsonlint": "1.6.2",
     "lodash": "4.6.1",
     "meow": "3.7.0",
-    "minimatch": "3.0.0",
+    "minimatch": "3.0.4",
     "mkdirp": "0.5.1",
     "omni-fetch": "0.1.0",
     "path-exists": "2.1.0"


### PR DESCRIPTION
Fixes this:
> warning jsonlint-cli > minimatch@3.0.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue